### PR TITLE
Added Norwegian Language Support and Updated .gitignore for Gradle Folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ expo-env.d.ts
 .expo
 dist/
 web-build/
+
+modules/my-module/android/.gradle/*
+modules/awesome-module/android/.gradle/*

--- a/modules/awesome-module/android/.settings/org.eclipse.buildship.core.prefs
+++ b/modules/awesome-module/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,0 +1,13 @@
+arguments=--init-script /var/folders/_k/cxdr3qg92fv0ds1w64jg05m80000gn/T/db3b08fc4a9ef609cb16b96b200fa13e563f396e9bb1ed0905fdab7bc3bc513b.gradle --init-script /var/folders/_k/cxdr3qg92fv0ds1w64jg05m80000gn/T/52cde0cfcf3e28b8b7510e992210d9614505e0911af0c190bd590d7158574963.gradle
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(VERSION(8.9))
+connection.project.dir=../../../android
+eclipse.preferences.version=1
+gradle.user.home=
+java.home=/Users/admin/.gradle/jdks/eclipse_adoptium-17-aarch64-os_x/jdk-17.0.10+7/Contents/Home
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/src/app/(tabs)/setting/language/index.tsx
+++ b/src/app/(tabs)/setting/language/index.tsx
@@ -22,9 +22,10 @@ const LanguageModal = () => {
 				onValueChange={(itemValue) => changeLanguage(itemValue)}
 			>
 				<Picker.Item color="white" style={styles.item} label="English" value="en" />
-				<Picker.Item color="white" style={styles.item} label="中文" value="zh" />
+				<Picker.Item color="white" style={styles.item} label="Norsk" value="no" />
 				<Picker.Item color="white" style={styles.item} label="한국어" value="ko" />
 				<Picker.Item color="white" style={styles.item} label="日本語" value="ja" />
+				<Picker.Item color="white" style={styles.item} label="中文" value="zh" />
 			</Picker>
 		</View>
 	)

--- a/src/locales/i18n.js
+++ b/src/locales/i18n.js
@@ -4,11 +4,15 @@ import * as RNLocalize from 'react-native-localize'
 import en from './en.json'
 import ja from './ja.json' // 日语
 import ko from './ko.json' // 韩语
+import no from './no.json'
 import zh from './zh.json'
 
 const resources = {
 	en: {
 		translation: en,
+	},
+	no: {
+		translation: no,
 	},
 	zh: {
 		translation: zh,

--- a/src/locales/languageMap.ts
+++ b/src/locales/languageMap.ts
@@ -4,6 +4,7 @@ export const languageMap = {
 	en: 'English',
 	ja: '日本語',
 	ko: '한국어',
+	no: 'Norsk',
 } as const
 
 export type LanguageCode = keyof typeof languageMap

--- a/src/locales/no.json
+++ b/src/locales/no.json
@@ -1,0 +1,74 @@
+{
+	"routes": {
+		"favorites": "Favoritter",
+		"collections": "Samlinger",
+		"songs": "Sanger",
+		"artists": "Artister",
+		"setting": "Innstillinger"
+	},
+	"favorites": {
+		"header": "Favorittsanger",
+		"search": "Søk i Favorittsanger"
+	},
+	"collections": {
+		"header": "Samlinger",
+		"search": "Søk i Samlinger",
+		"addPLaylsit": "Legg til spilleliste"
+	},
+	"songs": {
+		"header": "Sanger",
+		"search": "Søk i Sanger"
+	},
+	"artists": {
+		"header": "Artister",
+		"search": "Søk i Artister"
+	},
+	"setting": {
+		"header": "Innstillinger",
+		"addSource": "Legg til Kilde",
+		"local": "Lokal",
+		"localResource": "Lokal Ressurs",
+		"remoteResource": "Fjernressurs",
+		"webdavResource": "WebDAV Ressurs",
+		"addedResource": "Lagrede Ressurser",
+		"folder": "Mappe",
+		"about": "Om",
+		"language": "Språk"
+	},
+	"webdavAdd": {
+		"configName": "Ressursnavn",
+		"location": "Ressursplassering (Domene eller IP)",
+		"username": "Brukernavn",
+		"password": "Passord",
+		"saveBtn": "Lagre",
+		"deleteBtn": "Slett"
+	},
+	"about": {
+		"version": "Nåværende Versjon",
+		"checkUpdate": "Sjekk for Oppdateringer",
+		"report": "Rapporter Problem",
+		"website": "Offisiell Nettside",
+		"privacy": "Personvernerklæring"
+	},
+	"player": {
+		"tabs": {
+			"song": "Sang",
+			"lyric": "Tekst"
+		},
+		"playlist": {
+			"header": "Spilleliste"
+		}
+	},
+	"playlistAdd": {
+		"header": "Legg til Spilleliste",
+		"title": "Spillelistenavn",
+		"save": "Opprett"
+	},
+	"global": {
+		"refreshLib": "Oppdater Bibliotek",
+		"addTofavorite": "Legg til Favoritter",
+		"deleteFromfavorite": "Fjern fra Favoritter",
+		"addToPlayList": "Legg til Spilleliste",
+		"deleteFromPlayList": "Fjern fra Spilleliste"
+	}
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -7113,7 +7113,7 @@ prompts@^2.3.2, prompts@^2.4.2:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-prop-types@*, prop-types@^15.5.10, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
+prop-types@*, prop-types@^15.6.2, prop-types@^15.7.2, prop-types@^15.8.1:
   version "15.8.1"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.8.1.tgz#67d87bf1a694f48435cf332c24af10214a3140b5"
   integrity sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==
@@ -7252,10 +7252,6 @@ react-native-animatable@1.3.3:
   dependencies:
     prop-types "^15.7.2"
 
-"react-native-awesome-module@link:./modules/awesome-module":
-  version "0.0.0"
-  uid ""
-
 react-native-awesome-slider@^2.5.1:
   version "2.5.3"
   resolved "https://registry.yarnpkg.com/react-native-awesome-slider/-/react-native-awesome-slider-2.5.3.tgz#4f997c89e0f9223081911137c461ff372b7d3929"
@@ -7265,13 +7261,6 @@ react-native-base64@^0.2.1:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/react-native-base64/-/react-native-base64-0.2.1.tgz#3d0e73a649c4c0129f7b7695d3912456aebae847"
   integrity sha512-eHgt/MA8y5ZF0aHfZ1aTPcIkDWxza9AaEk4GcpIX+ZYfZ04RcaNahO+527KR7J44/mD3efYfM23O2C1N44ByWA==
-
-react-native-blur@^3.2.2:
-  version "3.2.2"
-  resolved "https://registry.yarnpkg.com/react-native-blur/-/react-native-blur-3.2.2.tgz#5bfb50638d148982c9560436554ed01d77d6d07d"
-  integrity sha512-r7zNQISL7kQX5ocQEet5QVOBzoXP+Nr3dO7Wql+fV6rebx/8I7eAUHnfITDx12WoOmRpiJjbt/4xF5gTEll6Uw==
-  dependencies:
-    prop-types "^15.5.10"
 
 react-native-context-menu-view@^1.16.0:
   version "1.16.0"


### PR DESCRIPTION
1. **Norwegian Language Support**: The project now fully supports Norwegian, with translations applied across the interface, including routes, collections, favorites, songs, artists, and settings. This enhancement improves the user experience for Norwegian-speaking users.
2. **Updated `.gitignore`**: The `.gradle` folders have been added to the `.gitignore` file to ensure these files are excluded when submitting PRs to the repository.

Screenshots are provided to demonstrate the Norwegian language interface in action.

![Simulator Screenshot](https://github.com/user-attachments/assets/42c241e6-d602-4951-96fe-1b66834f90d4)


